### PR TITLE
Cross platform GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,53 +20,76 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.16.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.9.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5393c75d4666f580f4cac0a968bc97c36076bb536a129f28210dac54ee127ed"
+checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.36.0",
  "atspi-common",
+ "phf",
  "serde",
- "thiserror 1.0.69",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.24.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12dc159d52233c43d9fe5415969433cbdd52c3d6e0df51bda7d447427b9986"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "immutable-chunkmap",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.17.4"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc6c1ecd82053d127961ad80a8beaa6004fb851a3a5b96506d7a6bd462403f6"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "once_cell",
 ]
 
 [[package]]
 name = "accesskit_unix"
-version = "0.12.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7f5cf6165be10a54b2655fa2e0e12b2509f38ed6fc43e11c31fdb7ee6230bb"
+checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -82,23 +105,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.23.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974e96c347384d9133427167fb8a58c340cb0496988dacceebdc1ed27071023b"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "paste",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.22.4"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea3522719f1c44564d03e9469a8e2f3a98b3a8a880bd66d0789c6b9c4a669dd"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -146,20 +169,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cc",
  "jni 0.22.4",
  "libc",
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 2.0.18",
 ]
@@ -266,9 +295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
+ "image",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
@@ -371,17 +403,6 @@ dependencies = [
  "futures-lite",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -508,20 +529,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.22.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
 dependencies = [
  "atspi-common",
- "atspi-connection",
  "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
-version = "0.6.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
 dependencies = [
  "enumflags2",
  "serde",
@@ -534,27 +554,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-connection"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
-dependencies = [
- "atspi-common",
- "atspi-proxies",
- "futures-lite",
- "zbus",
-]
-
-[[package]]
 name = "atspi-proxies"
-version = "0.6.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
 dependencies = [
  "atspi-common",
  "serde",
  "zbus",
- "zvariant",
 ]
 
 [[package]]
@@ -580,15 +587,6 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
-dependencies = [
- "bit-vec 0.7.0",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
@@ -597,16 +595,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.7.0"
+name = "bit-set"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
+]
 
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -616,26 +623,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -645,6 +637,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -704,7 +705,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -729,7 +730,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -743,7 +744,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -813,12 +814,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -926,42 +921,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "cocoa-foundation",
- "core-foundation 0.10.1",
- "core-graphics 0.24.0",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
- "objc",
-]
-
-[[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -969,37 +945,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "combine"
@@ -1054,20 +999,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -1080,26 +1012,6 @@ checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
  "libc",
 ]
 
@@ -1124,7 +1036,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -1144,7 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1188,16 +1100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,34 +1115,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1255,7 +1147,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
 ]
 
@@ -1302,9 +1194,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
+checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1312,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac2645a9bf4826eb4e91488b1f17b8eaddeef09396706b2f14066461338e24f"
+checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1323,47 +1215,53 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow 0.14.2",
  "glutin",
  "glutin-winit",
  "image",
  "js-sys",
  "log",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
+ "pollster",
+ "profiling",
  "raw-window-handle",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "winapi",
- "windows-sys 0.52.0",
+ "wgpu",
+ "windows-sys 0.61.2",
  "winit",
 ]
 
 [[package]]
 name = "egui"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
+checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
 dependencies = [
  "accesskit",
  "ahash",
+ "bitflags 2.13.1",
  "emath",
  "epaint",
+ "itertools 0.14.0",
  "log",
  "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
+checksum = "d2e6cfac0725563555fa4f91e9f799b9d7c6c5dd831fca6abc8234afc64b7a34"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1371,7 +1269,8 @@ dependencies = [
  "egui",
  "epaint",
  "log",
- "thiserror 1.0.69",
+ "profiling",
+ "thiserror 2.0.18",
  "type-map",
  "web-time",
  "wgpu",
@@ -1380,15 +1279,19 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
+checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
 dependencies = [
  "accesskit_winit",
- "ahash",
  "arboard",
+ "bytemuck",
  "egui",
  "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "profiling",
  "raw-window-handle",
  "smithay-clipboard",
  "web-time",
@@ -1398,26 +1301,24 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e39bccc683cd43adab530d8f21a13eb91e80de10bcc38c3f1c16601b6f62b26"
+checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
 dependencies = [
- "ahash",
  "bytemuck",
  "egui",
- "glow 0.14.2",
+ "glow",
  "log",
  "memoffset",
- "wasm-bindgen",
- "web-sys",
+ "profiling",
  "winit",
 ]
 
 [[package]]
 name = "egui_plot"
-version = "0.29.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dca4871c15d51aadb79534dcf51a8189e5de3426ee7b465eb7db9a0a81ea67"
+checksum = "302515219c63e7f380058ecc899c5a6b2c5fe9f140ef1d91c3b685c9f0355fa3"
 dependencies = [
  "ahash",
  "egui",
@@ -1432,9 +1333,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
+checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
 dependencies = [
  "bytemuck",
 ]
@@ -1468,26 +1369,34 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
+checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
 dependencies = [
- "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
+ "font-types",
+ "harfrust",
  "log",
  "nohash-hasher",
  "parking_lot",
+ "profiling",
+ "self_cell",
+ "skrifa",
+ "smallvec",
+ "unicode-general-category",
+ "unicode-segmentation",
+ "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483440db0b7993cf77a20314f08311dbe95675092405518c0677aa08c151a3ea"
+checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
 
 [[package]]
 name = "equivalent"
@@ -1542,6 +1451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1512,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "field-offset"
@@ -1626,6 +1556,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1720,12 +1665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,11 +1677,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1803,16 +1739,6 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1901,7 +1827,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1943,22 +1869,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "glow"
-version = "0.13.1"
+name = "glifo"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
 dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
 ]
 
 [[package]]
 name = "glow"
-version = "0.14.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1972,8 +1902,8 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.11.0",
- "cfg_aliases 0.2.1",
+ "bitflags 2.13.1",
+ "cfg_aliases",
  "cgl",
  "dispatch2",
  "glutin_egl_sys",
@@ -1997,7 +1927,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -2044,35 +1974,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "winapi",
- "windows 0.52.0",
+ "thiserror 2.0.18",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2081,7 +1993,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2092,7 +2004,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2148,6 +2060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,7 +2076,20 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -2164,7 +2098,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2172,20 +2106,19 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
-name = "hassle-rs"
-version = "0.11.0"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "bitflags 2.11.0",
- "com",
- "libc",
- "libloading 0.8.9",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2355,16 +2288,8 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png 0.18.1",
-]
-
-[[package]]
-name = "immutable-chunkmap"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
-dependencies = [
- "arrayvec",
+ "png",
+ "tiff",
 ]
 
 [[package]]
@@ -2397,6 +2322,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2504,7 +2438,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -2525,6 +2459,18 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2594,7 +2540,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -2653,6 +2599,7 @@ name = "lightspeed-gui"
 version = "0.4.2"
 dependencies = [
  "anyhow",
+ "dirs",
  "eframe",
  "egui_plot",
  "lightspeed-client",
@@ -2701,6 +2648,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linfa"
@@ -2791,24 +2744,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "matchers"
@@ -2854,21 +2798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.1.3",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,42 +2830,49 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.14.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8ac4080fb1e097c2c22acae467e46e4da72d941f02e82b67a87a2a89fa38b1"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
- "cocoa",
  "crossbeam-channel",
  "dpi",
  "gtk",
  "keyboard-types",
  "libxdo",
- "objc",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
- "thiserror 1.0.69",
- "windows-sys 0.59.0",
+ "png",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "naga"
-version = "22.1.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set 0.6.0",
- "bitflags 2.11.0",
- "cfg_aliases 0.1.1",
+ "bit-set 0.9.1",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
+ "num-traits",
+ "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
+ "thiserror 2.0.18",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2975,10 +2911,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "jni-sys 0.3.0",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2992,33 +2928,11 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys 0.3.0",
-]
-
-[[package]]
-name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -3067,6 +2981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3089,15 +3004,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
 ]
 
 [[package]]
@@ -3131,14 +3037,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -3147,7 +3053,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3160,8 +3066,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -3173,7 +3079,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3184,8 +3090,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3196,7 +3102,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -3207,7 +3113,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -3220,10 +3126,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3232,7 +3138,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -3250,8 +3156,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -3263,7 +3169,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3274,7 +3181,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3285,7 +3192,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -3297,10 +3204,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3309,11 +3228,24 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3332,8 +3264,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -3341,10 +3273,22 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3353,7 +3297,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3364,8 +3308,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -3409,6 +3353,15 @@ checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3526,10 +3479,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -3610,24 +3619,11 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3646,6 +3642,21 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -3769,7 +3780,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -3793,14 +3804,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-xml"
-version = "0.30.0"
+name = "quick-error"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3818,7 +3825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3860,7 +3867,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -3961,10 +3968,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
 
 [[package]]
 name = "rawpointer"
@@ -4006,6 +4031,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4020,7 +4055,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4029,18 +4064,18 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4119,7 +4154,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4132,7 +4167,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4226,7 +4261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -4280,7 +4315,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4296,6 +4331,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -4376,17 +4417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4440,6 +4470,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,7 +4506,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -4491,7 +4531,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -4544,11 +4584,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4606,7 +4646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -4720,6 +4759,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5049,22 +5102,23 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.17.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044d7738b3d50f288ddef035b793228740ad4d927f5466b0af55dc15e7e03cfe"
+checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
- "core-graphics 0.24.0",
  "crossbeam-channel",
  "dirs",
  "libappindicator",
  "muda",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
- "thiserror 1.0.69",
- "windows-sys 0.59.0",
+ "png",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5081,12 +5135,6 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.1",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -5106,6 +5154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,12 +5176,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -5160,10 +5208,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "vello_common",
+]
 
 [[package]]
 name = "version-compare"
@@ -5290,7 +5377,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -5302,7 +5389,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -5324,7 +5411,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5336,7 +5423,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5349,7 +5436,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5362,7 +5449,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5375,7 +5462,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5389,7 +5476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -5451,17 +5538,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "wgpu"
-version = "22.1.0"
+name = "weezl"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
  "document-features",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
+ "naga",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5476,86 +5575,151 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "22.1.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-vec 0.7.0",
- "bitflags 2.11.0",
- "cfg_aliases 0.1.1",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg_aliases",
  "document-features",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "22.0.0"
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bitflags 2.11.0",
- "cfg_aliases 0.1.1",
- "core-graphics-types 0.1.3",
- "glow 0.13.1",
+ "bit-set 0.9.1",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hassle-rs",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.9",
  "log",
- "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
+ "ordered-float",
  "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
  "profiling",
+ "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "winapi",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "22.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
+ "bytemuck",
  "js-sys",
+ "log",
+ "raw-window-handle",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5622,16 +5786,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -5641,12 +5795,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5655,11 +5821,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5667,6 +5857,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5685,10 +5886,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -5700,13 +5922,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5729,15 +5969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5837,6 +6068,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6058,14 +6298,14 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.0",
- "block2",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
- "core-graphics 0.23.2",
+ "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",
@@ -6075,7 +6315,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",
@@ -6180,22 +6420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "dlib",
  "log",
  "once_cell",
@@ -6248,13 +6478,12 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
  "async-io",
  "async-lock",
  "async-process",
@@ -6265,20 +6494,18 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite",
  "hex",
- "nix",
+ "libc",
  "ordered-stream",
- "rand 0.8.5",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
- "sha1",
- "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6286,9 +6513,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -6296,9 +6523,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6310,37 +6537,38 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "static_assertions",
+ "winnow 1.0.2",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "4.0.0"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
 dependencies = [
- "quick-xml 0.30.0",
  "serde",
- "static_assertions",
+ "winnow 1.0.2",
  "zbus_names",
  "zvariant",
 ]
@@ -6432,23 +6660,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
-name = "zvariant"
-version = "4.2.0"
+name = "zune-core"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "static_assertions",
+ "winnow 1.0.2",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -6459,11 +6703,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
  "syn 2.0.117",
+ "winnow 1.0.2",
 ]

--- a/client-gui/Cargo.toml
+++ b/client-gui/Cargo.toml
@@ -17,9 +17,12 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2"
 anyhow = { workspace = true }
+dirs = "6.0"
+
+tray-icon = "0.24.1"
+eframe = { version = "0.35", features = ["default"] }
+egui_plot = "0.36.0"
+webbrowser = "1"
+
 
 [target.'cfg(windows)'.dependencies]
-tray-icon = "0.17"
-eframe = { version = "0.29", features = ["default"] }
-egui_plot = "0.29"
-webbrowser = "1"

--- a/client-gui/src/app.rs
+++ b/client-gui/src/app.rs
@@ -1,3 +1,9 @@
+//! # LightSpeed GUI — App
+//!
+//! Main egui application state, UI layout, and pure helper functions.
+//! Wraps [`LightSpeedEngine`] in a platform-generic `<P: Platform>` struct
+//! so the same GUI code works on Windows (tray-icon) and Linux (stub tray).
+
 use std::net::SocketAddrV4;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -8,6 +14,7 @@ use egui_plot::{Line, Plot, PlotPoints};
 
 // ── Tray state enum ──────────────────────────────────────────────────────────
 
+/// The four states the tray icon can reflect in its color and tooltip.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TrayState {
     Disconnected,
@@ -19,6 +26,7 @@ use lightspeed_client::{EngineStatus, LightSpeedEngine};
 
 // ── Proxy nodes ────────────────────────────────────────────────────────────
 
+/// A proxy relay node the user can connect to.
 #[derive(Clone)]
 pub struct ProxyEntry {
     pub addr: SocketAddrV4,
@@ -77,6 +85,12 @@ pub const GAMES: &[(&str, &str, u16)] = &[
 
 // ── App struct ───────────────────────────────────────────────────────────────
 
+/// Platform-generic egui application for the LightSpeed status window.
+///
+/// Type parameter `P` selects the platform backend (Windows tray or Linux
+/// stub).  Most of the UI logic is platform-independent — only the tray
+/// interaction, font loading, port detection, and admin checks delegate to
+/// `P`.
 pub struct LightSpeedApp<P: Platform> {
     engine: Arc<Mutex<LightSpeedEngine>>,
     status: EngineStatus,

--- a/client-gui/src/app.rs
+++ b/client-gui/src/app.rs
@@ -1,28 +1,21 @@
-//! egui application + Windows tray icon for LightSpeed GUI.
-//!
-//! This module is only compiled on Windows (`#[cfg(windows)]` in main.rs).
-
 use std::net::SocketAddrV4;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::platform::{self, Platform, TrayAction, TrayHandle};
 use eframe::egui;
 use egui_plot::{Line, Plot, PlotPoints};
 
 // ── Tray state enum ──────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum TrayState {
+pub enum TrayState {
     Disconnected,
     Connected,
     Optimizing,
     Error,
 }
 use lightspeed_client::{EngineStatus, LightSpeedEngine};
-use tray_icon::{
-    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
-    TrayIcon, TrayIconBuilder, TrayIconEvent,
-};
 
 // ── Proxy nodes ────────────────────────────────────────────────────────────
 
@@ -45,7 +38,7 @@ const PROXIES: &[(&str, &str, &str)] = &[
 // ── Game list ──────────────────────────────────────────────────────────────
 
 /// (key, display name, default port)
-const GAMES: &[(&str, &str, u16)] = &[
+pub const GAMES: &[(&str, &str, u16)] = &[
     ("rust", "Rust (Facepunch)", 28015),
     ("fortnite", "Fortnite", 7777),
     ("cs2", "Counter-Strike 2", 27015),
@@ -57,27 +50,12 @@ const GAMES: &[(&str, &str, u16)] = &[
     ("pubg", "PUBG: Battlegrounds", 7777),
 ];
 
-// ── Tray menu item IDs ──────────────────────────────────────────────────────
-
-const MENU_SHOW: &str = "show";
-const MENU_CONNECT: &str = "connect";
-const MENU_DISCONNECT: &str = "disconnect";
-const MENU_QUIT: &str = "quit";
-
 // ── App struct ───────────────────────────────────────────────────────────────
 
-pub struct LightSpeedApp {
+pub struct LightSpeedApp<P: Platform> {
     engine: Arc<Mutex<LightSpeedEngine>>,
     status: EngineStatus,
-    tray: TrayIcon,
-    last_tray_state: TrayState,
-    fonts_setup: bool,
-
-    // ── Tray menu IDs ─────────────────────────────────────────────────────
-    id_show: tray_icon::menu::MenuId,
-    id_connect: tray_icon::menu::MenuId,
-    id_disconnect: tray_icon::menu::MenuId,
-    id_quit: tray_icon::menu::MenuId,
+    tray: P::Tray,
 
     // ── Proxy connection ─────────────────────────────────────────────────
     selected_proxy_idx: usize,
@@ -92,25 +70,21 @@ pub struct LightSpeedApp {
 
     // ── System state ──────────────────────────────────────────────────────
     #[allow(dead_code)]
-    npcap_installed: bool,
+    capture_available: bool,
     is_admin: bool,
+    fonts_setup: bool,
 
     // ── Advanced panel toggle ─────────────────────────────────────────────
-    /// True = "Advanced" expander is open (shows manual server IP input).
     show_advanced: bool,
 
-    // ── WinDivert diagnostics ─────────────────────────────────────────────
-    /// Wall-clock time when the current WinDivert boost session started.
-    /// Used to show a "port mismatch?" warning if no packets are seen after 15 s.
+    // ── Boost diagnostics ─────────────────────────────────────────────────
     boost_start: Option<std::time::Instant>,
-    /// Optional user-supplied port range override (e.g. "28015-28999").
-    /// When non-empty and parseable it overrides `windivert_port_range()`.
     custom_port_input: String,
 }
 
-impl LightSpeedApp {
+impl<P: Platform> LightSpeedApp<P> {
     pub fn new(engine: Arc<Mutex<LightSpeedEngine>>) -> Self {
-        let (tray, id_show, id_connect, id_disconnect, id_quit) = build_tray();
+        let tray = P::new_tray();
         let status = engine.lock().unwrap().snapshot();
 
         let auto_detected_game = try_auto_detect_game();
@@ -123,19 +97,13 @@ impl LightSpeedApp {
             })
             .unwrap_or(0);
 
-        let npcap_installed = check_npcap();
-        let is_admin = check_is_admin();
+        let is_admin = P::is_admin();
+        let capture_available = P::is_capture_available();
 
         Self {
             engine,
             status,
             tray,
-            last_tray_state: TrayState::Disconnected,
-            fonts_setup: false,
-            id_show,
-            id_connect,
-            id_disconnect,
-            id_quit,
             selected_proxy_idx: 0,
             show_connect_dialog: false,
             custom_proxy_input: String::new(),
@@ -143,8 +111,9 @@ impl LightSpeedApp {
             server_input: String::new(),
             fec_enabled: false,
             auto_detected_game,
-            npcap_installed,
+            capture_available,
             is_admin,
+            fonts_setup: false,
             show_advanced: false,
             boost_start: None,
             custom_port_input: String::new(),
@@ -159,166 +128,28 @@ impl LightSpeedApp {
     }
 }
 
-// ── Tray builder ─────────────────────────────────────────────────────────────
-
-fn build_tray() -> (
-    TrayIcon,
-    tray_icon::menu::MenuId,
-    tray_icon::menu::MenuId,
-    tray_icon::menu::MenuId,
-    tray_icon::menu::MenuId,
-) {
-    let item_show = MenuItem::with_id(MENU_SHOW, "Show window", true, None);
-    let item_connect = MenuItem::with_id(MENU_CONNECT, "Connect", true, None);
-    let item_disconnect = MenuItem::with_id(MENU_DISCONNECT, "Disconnect", true, None);
-    let item_quit = MenuItem::with_id(MENU_QUIT, "Quit", true, None);
-
-    let id_show = item_show.id().clone();
-    let id_connect = item_connect.id().clone();
-    let id_disconnect = item_disconnect.id().clone();
-    let id_quit = item_quit.id().clone();
-
-    let menu = Menu::new();
-    let _ = menu.append(&item_show);
-    let _ = menu.append(&PredefinedMenuItem::separator());
-    let _ = menu.append(&item_connect);
-    let _ = menu.append(&item_disconnect);
-    let _ = menu.append(&PredefinedMenuItem::separator());
-    let _ = menu.append(&item_quit);
-
-    // Start gray (disconnected) — will update on first frame via tray state machine.
-    let icon = lightning_icon(160, 160, 160);
-
-    let tray = TrayIconBuilder::new()
-        .with_menu(Box::new(menu))
-        .with_tooltip("\u{26a1} LightSpeed \u{2014} disconnected")
-        .with_icon(icon)
-        .build()
-        .expect("Failed to create tray icon");
-
-    (tray, id_show, id_connect, id_disconnect, id_quit)
-}
-
-/// Procedurally rasterise a ⚡ lightning-bolt silhouette into a 32×32 RGBA icon.
-///
-/// Uses a 6-vertex non-convex polygon (ray-casting fill) so no image crate is needed.
-/// `(r, g, b)` sets the bolt colour; background is transparent.
-fn lightning_icon(r: u8, g: u8, b: u8) -> tray_icon::Icon {
-    const SIZE: usize = 32;
-    // Bolt polygon: 6 vertices, clockwise, y-increasing downwards, normalised [0,1].
-    // Vertex sequence traces the ⚡ outline: top → mid-left → inner-jog → bottom → mid-right → inner-jog.
-    let poly: [(f32, f32); 6] = [
-        (0.55, 0.02), // top
-        (0.18, 0.48), // mid-left
-        (0.50, 0.48), // inner concave corner (step right)
-        (0.10, 0.98), // bottom-left tip
-        (0.82, 0.52), // mid-right
-        (0.50, 0.52), // inner concave corner (step left)
-    ];
-
-    let mut rgba = vec![0u8; SIZE * SIZE * 4];
-    for y in 0..SIZE {
-        for x in 0..SIZE {
-            let px = (x as f32 + 0.5) / SIZE as f32;
-            let py = (y as f32 + 0.5) / SIZE as f32;
-            if point_in_poly(px, py, &poly) {
-                let idx = (y * SIZE + x) * 4;
-                rgba[idx] = r;
-                rgba[idx + 1] = g;
-                rgba[idx + 2] = b;
-                rgba[idx + 3] = 255;
-            }
-        }
-    }
-    tray_icon::Icon::from_rgba(rgba, SIZE as u32, SIZE as u32)
-        .expect("Failed to build tray icon from RGBA data")
-}
-
-/// Ray-casting point-in-polygon test (works for non-convex simple polygons).
-fn point_in_poly(px: f32, py: f32, poly: &[(f32, f32)]) -> bool {
-    let n = poly.len();
-    let mut inside = false;
-    let mut j = n - 1;
-    for i in 0..n {
-        let (xi, yi) = poly[i];
-        let (xj, yj) = poly[j];
-        if ((yi > py) != (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi) + xi) {
-            inside = !inside;
-        }
-        j = i;
-    }
-    inside
-}
-
-/// Load Segoe UI Emoji (and Symbol) from the Windows Fonts directory as egui fallback fonts.
-///
-/// Called once on first frame. Silently skipped if the files are absent (older OS / CI).
-/// Text still renders correctly using egui's bundled Ubuntu-Light; the system emoji font
-/// adds coverage for glyphs like 🎮 🟢 🪄 🔑 ✅ that are absent from the bundled subset.
-fn setup_fonts(ctx: &egui::Context) {
-    let mut fonts = egui::FontDefinitions::default();
-
-    // Segoe UI Emoji — full Unicode 14+ colour/monochrome emoji (Windows 10/11).
-    if let Ok(bytes) = std::fs::read(r"C:\Windows\Fonts\seguiemj.ttf") {
-        fonts
-            .font_data
-            .insert("seguiemj".to_owned(), egui::FontData::from_owned(bytes));
-        for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
-            fonts
-                .families
-                .entry(family)
-                .or_default()
-                .push("seguiemj".to_owned());
-        }
-    }
-
-    // Segoe UI Symbol — BMP symbol coverage (⚡ ⚠ ▶ ■ ● ℹ ↗ etc.).
-    if let Ok(bytes) = std::fs::read(r"C:\Windows\Fonts\seguisym.ttf") {
-        fonts
-            .font_data
-            .insert("seguisym".to_owned(), egui::FontData::from_owned(bytes));
-        fonts
-            .families
-            .entry(egui::FontFamily::Proportional)
-            .or_default()
-            .push("seguisym".to_owned());
-    }
-
-    ctx.set_fonts(fonts);
-}
-
 // ── eframe::App impl ─────────────────────────────────────────────────────────
 
-impl eframe::App for LightSpeedApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // One-time first-frame setup: emoji font fallback.
+impl<P: Platform> eframe::App for LightSpeedApp<P> {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+
+        // One-time first-frame setup: platform-specific fonts.
         if !self.fonts_setup {
             self.fonts_setup = true;
-            setup_fonts(ctx);
+            P::setup_fonts(&ctx);
         }
 
-        // ── Poll tray/menu events each frame ─────────────────────────────
-        // Using receiver() instead of set_event_handler() so events are
-        // delivered correctly even when running as Administrator (UIPI
-        // blocks callback-based messages from Explorer at medium IL).
-        while let Ok(event) = MenuEvent::receiver().try_recv() {
-            tracing::debug!("Tray menu event: {:?}", event.id);
-            if event.id == self.id_show {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
-            } else if event.id == self.id_connect {
-                let proxy = self.selected_proxy_addr();
-                self.engine.lock().unwrap().connect(proxy);
-            } else if event.id == self.id_disconnect {
-                self.engine.lock().unwrap().disconnect();
-            } else if event.id == self.id_quit {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-            }
-        }
-        while let Ok(event) = TrayIconEvent::receiver().try_recv() {
-            if matches!(event, TrayIconEvent::DoubleClick { .. }) {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+        // ── Poll tray events ─────────────────────────────────────────────
+        for action in self.tray.poll_events(&ctx) {
+            match action {
+                TrayAction::Connect => {
+                    let proxy = self.selected_proxy_addr();
+                    self.engine.lock().unwrap().connect(proxy);
+                }
+                TrayAction::Disconnect => {
+                    self.engine.lock().unwrap().disconnect();
+                }
             }
         }
 
@@ -352,30 +183,12 @@ impl eframe::App for LightSpeedApp {
                 TrayState::Disconnected
             };
 
-            if new_tray_state != self.last_tray_state {
-                self.last_tray_state = new_tray_state;
-                let (r, g, b): (u8, u8, u8) = match new_tray_state {
-                    TrayState::Disconnected => (160, 160, 160), // gray
-                    TrayState::Connected => (255, 200, 60),     // amber
-                    TrayState::Optimizing => (80, 210, 120),    // green
-                    TrayState::Error => (220, 80, 80),          // red
-                };
-                let tooltip: String = match new_tray_state {
-                    TrayState::Disconnected => "\u{26a1} LightSpeed \u{2014} disconnected".into(),
-                    TrayState::Connected => format!(
-                        "\u{26a1} LightSpeed \u{2014} connected \u{00b7} RTT {:.0}ms",
-                        self.status.latest_rtt_ms
-                    ),
-                    TrayState::Optimizing => "\u{26a1} LightSpeed \u{2014} optimizing".into(),
-                    TrayState::Error => "\u{26a1} LightSpeed \u{2014} error".into(),
-                };
-                let _ = self.tray.set_icon(Some(lightning_icon(r, g, b)));
-                let _ = self.tray.set_tooltip(Some(&tooltip));
-            }
+            self.tray
+                .set_state(new_tray_state, self.status.latest_rtt_ms);
         }
 
         // ── Main panel ────────────────────────────────────────────────────
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             // ── Header ───────────────────────────────────────────────────
             ui.horizontal(|ui| {
                 ui.heading("⚡ LightSpeed");
@@ -449,9 +262,8 @@ impl eframe::App for LightSpeedApp {
                     .enumerate()
                     .map(|(i, &v)| [i as f64, v])
                     .collect();
-                let line = Line::new(points)
-                    .color(egui::Color32::from_rgb(100, 180, 255))
-                    .name("RTT (ms)");
+                let line = Line::new("RTT (ms)", points)
+                    .color(egui::Color32::from_rgb(100, 180, 255));
                 Plot::new("rtt_plot")
                     .height(80.0)
                     .allow_drag(false)
@@ -527,9 +339,9 @@ impl eframe::App for LightSpeedApp {
 
                     if elapsed < 15 {
                         // First 15 s: friendly "finding server" indicator.
-                        egui::Frame::none()
+                        egui::Frame::new()
                             .fill(egui::Color32::from_rgb(20, 30, 45))
-                            .rounding(4.0)
+                            .corner_radius(4.0)
                             .inner_margin(8.0)
                             .show(ui, |ui: &mut egui::Ui| {
                                 ui.colored_label(
@@ -544,10 +356,10 @@ impl eframe::App for LightSpeedApp {
                     } else {
                         // 15 s+ with no packets → likely port mismatch — amber warning.
                         let (lo, hi) = parse_custom_port_range(&self.custom_port_input)
-                            .unwrap_or_else(|| windivert_port_range(self.selected_game_idx));
-                        egui::Frame::none()
+                            .unwrap_or_else(|| platform::default_port_range(self.selected_game_idx));
+                        egui::Frame::new()
                             .fill(egui::Color32::from_rgb(55, 40, 8))
-                            .rounding(4.0)
+                            .corner_radius(4.0)
                             .inner_margin(8.0)
                             .show(ui, |ui: &mut egui::Ui| {
                                 ui.colored_label(
@@ -567,9 +379,9 @@ impl eframe::App for LightSpeedApp {
                             });
                     }
                 } else {
-                    egui::Frame::none()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(25, 40, 15))
-                        .rounding(4.0)
+                        .corner_radius(4.0)
                         .inner_margin(8.0)
                         .show(ui, |ui: &mut egui::Ui| {
                             ui.colored_label(
@@ -640,7 +452,7 @@ impl eframe::App for LightSpeedApp {
                         format!("⚠ Drops: {}", self.status.windivert_errors),
                     )
                     .on_hover_ui(|ui| {
-                        ui.label("Packets that couldn't be delivered back to your game.\n\
+                        ui.label("Packet that couldn't be delivered back to your game.\n\
                                   Usually a firewall issue — see Troubleshooting.");
                         ui.hyperlink_to("📖 Fix Drops",
                             "https://github.com/ShibbityShwab/lightspeed/wiki/Troubleshooting#packets-sent-climbing-packets-delivered-0");
@@ -656,9 +468,9 @@ impl eframe::App for LightSpeedApp {
 
                     if elapsed < 15 {
                         // First 15 s: friendly "finding server" indicator.
-                        egui::Frame::none()
+                        egui::Frame::new()
                             .fill(egui::Color32::from_rgb(20, 30, 45))
-                            .rounding(4.0)
+                            .corner_radius(4.0)
                             .inner_margin(8.0)
                             .show(ui, |ui: &mut egui::Ui| {
                                 ui.colored_label(
@@ -673,10 +485,10 @@ impl eframe::App for LightSpeedApp {
                     } else {
                         // 15 s+ with no packets → likely port mismatch — amber warning.
                         let (lo, hi) = parse_custom_port_range(&self.custom_port_input)
-                            .unwrap_or_else(|| windivert_port_range(self.selected_game_idx));
-                        egui::Frame::none()
+                            .unwrap_or_else(|| platform::default_port_range(self.selected_game_idx));
+                        egui::Frame::new()
                             .fill(egui::Color32::from_rgb(55, 40, 8))
-                            .rounding(4.0)
+                            .corner_radius(4.0)
                             .inner_margin(8.0)
                             .show(ui, |ui: &mut egui::Ui| {
                                 ui.colored_label(
@@ -696,9 +508,9 @@ impl eframe::App for LightSpeedApp {
                             });
                     }
                 } else {
-                    egui::Frame::none()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(25, 40, 15))
-                        .rounding(4.0)
+                        .corner_radius(4.0)
                         .inner_margin(8.0)
                         .show(ui, |ui: &mut egui::Ui| {
                             ui.colored_label(
@@ -774,9 +586,9 @@ impl eframe::App for LightSpeedApp {
                 // Diagnostic: proxy working but no game packets seen yet.
                 if self.status.capture_pkts_in > 5 && self.status.capture_pkts_out == 0 {
                     ui.add_space(2.0);
-                    egui::Frame::none()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(55, 44, 8))
-                        .rounding(4.0)
+                        .corner_radius(4.0)
                         .inner_margin(8.0)
                         .show(ui, |ui: &mut egui::Ui| {
                             ui.colored_label(
@@ -789,9 +601,9 @@ impl eframe::App for LightSpeedApp {
                 }
 
                 ui.add_space(4.0);
-                egui::Frame::none()
+                egui::Frame::new()
                     .fill(egui::Color32::from_rgb(20, 45, 30))
-                    .rounding(4.0)
+                    .corner_radius(4.0)
                     .inner_margin(8.0)
                     .show(ui, |ui: &mut egui::Ui| {
                         ui.colored_label(
@@ -867,9 +679,9 @@ impl eframe::App for LightSpeedApp {
                 ui.add_space(4.0);
                 let instruction =
                     connect_instruction(self.selected_game_idx, self.status.redirect_local_port);
-                egui::Frame::none()
+                egui::Frame::new()
                     .fill(egui::Color32::from_rgb(30, 50, 30))
-                    .rounding(4.0)
+                    .corner_radius(4.0)
                     .inner_margin(8.0)
                     .show(ui, |ui: &mut egui::Ui| {
                         ui.colored_label(egui::Color32::from_rgb(150, 255, 150), &instruction);
@@ -966,11 +778,10 @@ impl eframe::App for LightSpeedApp {
                 ui.add_space(8.0);
 
                 // ── Method info strip ─────────────────────────────────────
-                // Show what backend will be used (no tabs — just informational).
                 if self.is_admin {
-                    egui::Frame::none()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(20, 35, 50))
-                        .rounding(4.0)
+                        .corner_radius(4.0)
                         .inner_margin(8.0)
                         .show(ui, |ui: &mut egui::Ui| {
                             ui.horizontal(|ui| {
@@ -998,9 +809,9 @@ impl eframe::App for LightSpeedApp {
                         });
                 } else {
                     // Not admin — show restart nudge inline
-                    egui::Frame::none()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(55, 40, 10))
-                        .rounding(4.0)
+                        .corner_radius(4.0)
                         .inner_margin(8.0)
                         .show(ui, |ui: &mut egui::Ui| {
                             ui.horizontal(|ui| {
@@ -1028,7 +839,7 @@ impl eframe::App for LightSpeedApp {
                                 )
                                 .clicked()
                             {
-                                relaunch_as_admin();
+                                P::relaunch_as_admin();
                             }
                         });
                 }
@@ -1070,10 +881,9 @@ impl eframe::App for LightSpeedApp {
                     .clicked()
                     && self.is_admin
                 {
-                    // Auto-pick best backend: WinDivert (kernel) is always preferred
-                    // when running as admin — no fallback needed.
+                    // Warm up port detection for diagnostic logging.
                     let _ = parse_custom_port_range(&self.custom_port_input)
-                            .unwrap_or_else(|| detect_windivert_port_range(self.selected_game_idx));
+                        .unwrap_or_else(|| P::detect_game_ports(self.selected_game_idx));
 
                     let game_key = GAMES[self.selected_game_idx].0;
                     let result = self.engine.lock().unwrap().start_interceptor(
@@ -1086,7 +896,6 @@ impl eframe::App for LightSpeedApp {
                         tracing::error!("start_interceptor failed: {}", e);
                     } else {
                         self.boost_start = Some(std::time::Instant::now());
-                        self.last_tray_state = TrayState::Connected; // force tray update
                     }
                 }
 
@@ -1111,9 +920,9 @@ impl eframe::App for LightSpeedApp {
 
                 if self.show_advanced {
                     ui.add_space(4.0);
-                    egui::Frame::none()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(25, 25, 35))
-                        .rounding(4.0)
+                        .corner_radius(4.0)
                         .inner_margin(8.0)
                         .show(ui, |ui: &mut egui::Ui| {
                             ui.weak(
@@ -1246,7 +1055,7 @@ impl eframe::App for LightSpeedApp {
                 .resizable(false)
                 .collapsible(false)
                 .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
-                .show(ctx, |ui| {
+                .show(&ctx, |ui| {
                     ui.label("Proxy address (ip:port):");
                     ui.text_edit_singleline(&mut self.custom_proxy_input);
                     ui.add_space(4.0);
@@ -1278,7 +1087,7 @@ impl eframe::App for LightSpeedApp {
     }
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Pure helpers (no platform dependency) ─────────────────────────────────────
 
 fn rtt_colour(rtt_ms: f64) -> egui::Color32 {
     if rtt_ms < 60.0 {
@@ -1327,198 +1136,16 @@ fn try_auto_detect_game() -> Option<String> {
     }
 }
 
-/// Check if Npcap is installed on this Windows system.
-fn check_npcap() -> bool {
-    use std::process::Command;
-    Command::new("sc")
-        .args(["query", "npcap"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-/// Check if the current process is running as Administrator.
-fn check_is_admin() -> bool {
-    use std::process::Command;
-    // `net session` requires admin — succeeds if elevated, fails if not.
-    Command::new("net")
-        .args(["session"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-/// Determine the WinDivert port range for the selected game using real-time
-/// process inspection where available, with a wide static range as fallback.
-///
-/// For Rust, this calls `detect_rust_ports_netstat()` to find the actual UDP
-/// sockets open by `RustClient.exe` — so it works even on community servers
-/// that use completely non-standard ports.  For other games it delegates to
-/// `windivert_port_range()`.
-fn detect_windivert_port_range(game_idx: usize) -> (u16, u16) {
-    let (key, _, _) = GAMES[game_idx];
-    if key == "rust" {
-        if let Some(range) = detect_rust_ports_netstat() {
-            tracing::info!(
-                "🔍 RustClient.exe netstat-detected port range: {}-{}",
-                range.0,
-                range.1
-            );
-            return range;
-        }
-        tracing::debug!(
-            "RustClient.exe netstat detection failed — using wide fallback 28015-28999"
-        );
-    }
-    windivert_port_range(game_idx)
-}
-
 /// Known Steam-service UDP ports that RustClient.exe keeps open for
 /// Steam NAT punch / relay etc. — we skip these so the WinDivert filter
 /// doesn't intercept Steam traffic instead of game traffic.
-const STEAM_SERVICE_PORTS: &[u16] = &[
+pub const STEAM_SERVICE_PORTS: &[u16] = &[
     3478, 4379, 4380,  // Steam NAT punch / relay
     27005, // Steam client source
     27015, // Steam SRCDS / query
     27020, // Steam TV
     27036, 27037, // Steam Remote Play
 ];
-
-/// Detect the actual UDP port(s) that `RustClient.exe` is using by
-/// querying `netstat -ano` and cross-referencing with `tasklist`.
-///
-/// Returns `Some((lo, hi))` — the min/max of detected game ports with a
-/// small headroom window — or `None` if the process isn't found or has no
-/// relevant sockets.
-#[cfg(target_os = "windows")]
-fn detect_rust_ports_netstat() -> Option<(u16, u16)> {
-    use std::process::Command;
-
-    // ── Step 1: find PID of RustClient.exe ───────────────────────────────
-    let tl = Command::new("tasklist")
-        .args(["/FI", "IMAGENAME eq RustClient.exe", "/FO", "CSV", "/NH"])
-        .output()
-        .ok()?;
-    let text = String::from_utf8_lossy(&tl.stdout);
-    if text.trim().to_ascii_lowercase().starts_with("info:") || text.trim().is_empty() {
-        tracing::debug!("RustClient.exe not found in tasklist");
-        return None;
-    }
-    let pid: u32 = text
-        .lines()
-        .filter_map(|line| {
-            let mut fields = line.split(',');
-            let _name = fields.next()?;
-            fields.next()?.trim().trim_matches('"').parse().ok()
-        })
-        .next()?;
-
-    tracing::debug!("RustClient.exe PID = {}", pid);
-
-    // ── Step 2: enumerate UDP endpoints owned by that PID ─────────────────
-    let ns = Command::new("netstat")
-        .args(["-ano", "-p", "UDP"])
-        .output()
-        .ok()?;
-
-    let pid_str = pid.to_string();
-    let mut ports: Vec<u16> = Vec::new();
-
-    for line in String::from_utf8_lossy(&ns.stdout).lines() {
-        // Windows netstat UDP output format:
-        // Column 0: Proto (UDP)
-        // Column 1: Local Address (your_ip:your_port)
-        // Column 2: Foreign Address (*:* or ip:port)
-        // Column 3: State (blank for UDP)
-        // Column 4: PID (if -o is used)
-        // Note: Sometimes Column 3 is missing in UDP output.
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 4 {
-            continue;
-        }
-        if !parts[0].eq_ignore_ascii_case("UDP") {
-            continue;
-        }
-
-        // Find PID - it's usually the last part
-        let line_pid = parts.last().unwrap_or(&"");
-        if *line_pid != pid_str {
-            continue;
-        }
-
-        // We want the FOREIGN port (the game server port), not our LOCAL port.
-        // For UDP, netstat -ano usually shows "*:*" for the foreign address
-        // until a packet is sent. If it's still "*:*", we have to fallback
-        // to our local port as a hint, or use the wide default.
-        let foreign_addr = parts[2];
-        if let Some(port_str) = foreign_addr.rsplit(':').next() {
-            if let Ok(port) = port_str.parse::<u16>() {
-                if port >= 1024 && !STEAM_SERVICE_PORTS.contains(&port) && !ports.contains(&port) {
-                    ports.push(port);
-                }
-            }
-        }
-
-        // If foreign port is unknown (*), check the local port.
-        // In some games, the local port matches the remote port (source=dest).
-        if ports.is_empty() {
-            if let Some(port_str) = parts[1].rsplit(':').next() {
-                if let Ok(port) = port_str.parse::<u16>() {
-                    if port >= 28015 && port <= 30000 && !ports.contains(&port) {
-                        ports.push(port);
-                    }
-                }
-            }
-        }
-    }
-
-    tracing::debug!(
-        "RustClient.exe (PID {}) candidate UDP ports: {:?}",
-        pid,
-        ports
-    );
-
-    if ports.is_empty() {
-        return None;
-    }
-
-    let lo = *ports.iter().min().unwrap();
-    let hi = *ports.iter().max().unwrap();
-    // Small headroom: ensure at least a 3-port window around the detected range.
-    Some((lo, hi.max(lo + 2)))
-}
-
-#[cfg(not(target_os = "windows"))]
-fn detect_rust_ports_netstat() -> Option<(u16, u16)> {
-    None
-}
-
-/// Returns the WinDivert port range (lo, hi) for the selected game.
-///
-/// These match the game-server UDP port ranges used by each title.
-/// WinDivert opens a broad filter over the range and auto-detects the
-/// actual server from the first intercepted outbound packet.
-///
-/// Ranges are intentionally wide because community servers regularly use
-/// non-default ports.  The stale-server timeout (5 s) prevents locking on
-/// to wrong hosts even with a wide filter.
-fn windivert_port_range(game_idx: usize) -> (u16, u16) {
-    let (key, _, default_port) = GAMES[game_idx];
-    match key {
-        // Community Rust servers use any port in 28015–30000.
-        // Official Facepunch servers default to 28015.
-        "rust" => (28015, 30000),
-        // Source-engine games share the 27000 block; matchmaking,
-        // community, and dedicated server ports vary widely.
-        "cs2" => (27015, 27100),
-        "dota2" => (27015, 27100),
-        "valorant" => (7000, 7500),
-        "apex" => (37000, 37050),
-        "lol" => (5000, 5500),
-        "pubg" => (7777, 7843),
-        _ => (default_port, default_port),
-    }
-}
 
 /// Parse a user-supplied port range string.
 ///
@@ -1543,19 +1170,4 @@ fn parse_custom_port_range(s: &str) -> Option<(u16, u16)> {
         let p = s.parse::<u16>().ok()?;
         Some((p, p))
     }
-}
-
-/// Relaunch the current exe with elevated privileges via PowerShell UAC.
-fn relaunch_as_admin() {
-    let exe = std::env::current_exe()
-        .unwrap_or_default()
-        .display()
-        .to_string();
-    // Use Start-Process -Verb RunAs to show UAC prompt.
-    let script = format!("Start-Process '{}' -Verb RunAs", exe.replace('\'', "''"));
-    let _ = std::process::Command::new("powershell")
-        .args(["-WindowStyle", "Hidden", "-Command", &script])
-        .spawn();
-    // Exit current (unelevated) process — the new elevated one will start.
-    std::process::exit(0);
 }

--- a/client-gui/src/app.rs
+++ b/client-gui/src/app.rs
@@ -19,21 +19,46 @@ use lightspeed_client::{EngineStatus, LightSpeedEngine};
 
 // ── Proxy nodes ────────────────────────────────────────────────────────────
 
-/// (addr, label, recommended-for hint)
-/// Populated at runtime from LIGHTSPEED_PROXIES env var or falls back to placeholders.
-/// Set LIGHTSPEED_PROXIES='["YOUR_IP:4434","YOUR_IP_2:4434"]' to configure.
-const PROXIES: &[(&str, &str, &str)] = &[
-    (
-        "YOUR_LAX_IP:4434",
-        "LAX — US West",
-        "Best for NA/EU servers",
-    ),
-    (
-        "YOUR_SGP_IP:4434",
-        "SGP — Singapore",
-        "Best for SEA/AU servers",
-    ),
-];
+#[derive(Clone)]
+pub struct ProxyEntry {
+    pub addr: SocketAddrV4,
+    pub label: String,
+}
+
+/// Loaded from `LIGHTSPEED_PROXIES` env var (comma-separated `addr:port`)
+/// or falls back to localhost placeholders.
+///   LIGHTSPEED_PROXIES="1.2.3.4:4434,5.6.7.8:4434"
+pub fn load_proxies() -> Vec<ProxyEntry> {
+    if let Ok(val) = std::env::var("LIGHTSPEED_PROXIES") {
+        let proxies: Vec<_> = val
+            .split(',')
+            .filter_map(|s| {
+                let s = s.trim();
+                if s.is_empty() {
+                    return None;
+                }
+                match s.parse::<SocketAddrV4>() {
+                    Ok(addr) => Some(ProxyEntry {
+                        addr,
+                        label: "Custom".into(),
+                    }),
+                    Err(_) => {
+                        tracing::warn!("Skipping invalid proxy address: {s}");
+                        None
+                    }
+                }
+            })
+            .collect();
+        if !proxies.is_empty() {
+            return proxies;
+        }
+        tracing::warn!("LIGHTSPEED_PROXIES set but no valid addresses found — using defaults");
+    }
+    vec![
+        ProxyEntry { addr: "127.0.0.1:4434".parse().expect("valid"), label: "LAX — US West".into() },
+        ProxyEntry { addr: "127.0.0.1:4434".parse().expect("valid"), label: "SGP — Singapore".into() },
+    ]
+}
 
 // ── Game list ──────────────────────────────────────────────────────────────
 
@@ -61,6 +86,9 @@ pub struct LightSpeedApp<P: Platform> {
     selected_proxy_idx: usize,
     show_connect_dialog: bool,
     custom_proxy_input: String,
+    show_proxy_manager: bool,
+    manager_label_input: String,
+    manager_addr_input: String,
 
     // ── Game routing ──────────────────────────────────────────────────────
     selected_game_idx: usize,
@@ -69,8 +97,6 @@ pub struct LightSpeedApp<P: Platform> {
     auto_detected_game: Option<String>,
 
     // ── System state ──────────────────────────────────────────────────────
-    #[allow(dead_code)]
-    capture_available: bool,
     is_admin: bool,
     fonts_setup: bool,
 
@@ -80,6 +106,8 @@ pub struct LightSpeedApp<P: Platform> {
     // ── Boost diagnostics ─────────────────────────────────────────────────
     boost_start: Option<std::time::Instant>,
     custom_port_input: String,
+
+    proxies: Vec<ProxyEntry>,
 }
 
 impl<P: Platform> LightSpeedApp<P> {
@@ -98,7 +126,8 @@ impl<P: Platform> LightSpeedApp<P> {
             .unwrap_or(0);
 
         let is_admin = P::is_admin();
-        let capture_available = P::is_capture_available();
+
+        let proxies = load_proxies();
 
         Self {
             engine,
@@ -107,24 +136,24 @@ impl<P: Platform> LightSpeedApp<P> {
             selected_proxy_idx: 0,
             show_connect_dialog: false,
             custom_proxy_input: String::new(),
+            show_proxy_manager: false,
+            manager_label_input: String::new(),
+            manager_addr_input: String::new(),
             selected_game_idx,
             server_input: String::new(),
             fec_enabled: false,
             auto_detected_game,
-            capture_available,
             is_admin,
             fonts_setup: false,
             show_advanced: false,
             boost_start: None,
             custom_port_input: String::new(),
+            proxies,
         }
     }
 
     fn selected_proxy_addr(&self) -> SocketAddrV4 {
-        PROXIES[self.selected_proxy_idx]
-            .0
-            .parse()
-            .expect("proxy addr is always valid")
+        self.proxies[self.selected_proxy_idx].addr
     }
 }
 
@@ -215,13 +244,16 @@ impl<P: Platform> eframe::App for LightSpeedApp<P> {
                             "https://github.com/ShibbityShwab/lightspeed/wiki/Choosing-a-Boost-Server");
                     });
                 let prev = self.selected_proxy_idx;
-                for (i, (_, label, hint)) in PROXIES.iter().enumerate() {
-                    let btn = ui.selectable_value(&mut self.selected_proxy_idx, i, *label);
-                    btn.on_hover_text(*hint);
+                for (i, entry) in self.proxies.iter().enumerate() {
+                    let btn = ui.selectable_value(&mut self.selected_proxy_idx, i, &entry.label);
+                    btn.on_hover_text(format!("{}", entry.addr));
                 }
                 if self.selected_proxy_idx != prev {
                     let proxy = self.selected_proxy_addr();
                     self.engine.lock().unwrap().connect(proxy);
+                }
+                if ui.button("✎ Manage").clicked() {
+                    self.show_proxy_manager = true;
                 }
             });
 
@@ -280,12 +312,6 @@ impl<P: Platform> eframe::App for LightSpeedApp<P> {
             // ── Game Routing section ──────────────────────────────────────
             ui.heading("🎮 Game Routing");
             ui.add_space(4.0);
-
-            let any_active =
-                self.status.redirect_active
-                    || self.status.capture_active
-                    || self.status.windivert_active
-                    || self.status.interceptor_active;
 
             if self.status.interceptor_active {
                 // ── BOOST ENGAGED (OOP Interceptor) state ──────────────────────
@@ -709,7 +735,6 @@ impl<P: Platform> eframe::App for LightSpeedApp<P> {
                 }
             } else {
                 // ── IDLE: single Optimize button ──────────────────────────
-                let _ = any_active;
 
                 // ── Game auto-detect banner ───────────────────────────────
                 if let Some(ref detected) = self.auto_detected_game {
@@ -1071,6 +1096,67 @@ impl<P: Platform> eframe::App for LightSpeedApp<P> {
                         }
                     });
                 });
+        }
+
+        // ── Proxy manager window ─────────────────────────────────────────
+        if self.show_proxy_manager {
+            let mut remove_idx: Option<usize> = None;
+            let mut add_addr: Option<SocketAddrV4> = None;
+
+            egui::Window::new("Proxy Manager")
+                .resizable(false)
+                .collapsible(false)
+                .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+                .show(&ctx, |ui| {
+                    for (i, entry) in self.proxies.iter().enumerate() {
+                        ui.horizontal(|ui| {
+                            ui.label(format!("{}.", i + 1));
+                            ui.label(&entry.label);
+                            ui.label(entry.addr.to_string());
+                            if ui.button("✕").clicked() {
+                                remove_idx = Some(i);
+                            }
+                        });
+                    }
+
+                    ui.separator();
+                    ui.horizontal(|ui| {
+                        ui.label("Label:");
+                        ui.text_edit_singleline(&mut self.manager_label_input);
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Addr:");
+                        ui.text_edit_singleline(&mut self.manager_addr_input);
+                    });
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Add Proxy").clicked() {
+                            if self.manager_addr_input.parse::<SocketAddrV4>().is_ok() {
+                                add_addr = Some(self.manager_addr_input.parse().unwrap());
+                            }
+                        }
+                        if ui.button("Close").clicked() {
+                            self.show_proxy_manager = false;
+                        }
+                    });
+                });
+
+            if let Some(idx) = remove_idx {
+                self.proxies.remove(idx);
+                if !self.proxies.is_empty() {
+                    self.selected_proxy_idx = self.selected_proxy_idx.min(self.proxies.len() - 1);
+                }
+            }
+            if let Some(addr) = add_addr {
+                let label = if self.manager_label_input.is_empty() {
+                    addr.to_string()
+                } else {
+                    self.manager_label_input.clone()
+                };
+                self.proxies.push(ProxyEntry { addr, label });
+                self.manager_label_input.clear();
+                self.manager_addr_input.clear();
+            }
         }
 
         // ── Repaint schedule ─────────────────────────────────────────────

--- a/client-gui/src/main.rs
+++ b/client-gui/src/main.rs
@@ -4,24 +4,28 @@
 //! with code 1, so it can be compiled cross-platform but should only be
 //! installed on Windows.
 
-#[cfg(windows)]
 mod app;
+mod platform;
 
 fn main() -> anyhow::Result<()> {
     windows_main()
 }
 
-#[cfg(windows)]
+// #[cfg(windows)]
 fn windows_main() -> anyhow::Result<()> {
     use eframe::egui;
     use std::sync::{Arc, Mutex};
 
     // Redirect tracing to a file since GUI apps have no console.
     // Use a simple file appender for straightforward single-file logging.
+    let path = dirs::data_local_dir()
+        .unwrap_or_default()
+        .join("lightspeed")
+        .join("gui-trace.log");
     let file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open("C:\\Users\\User\\ls-gui-trace.log")
+        .open(path)
         .expect("Failed to open log file");
     let file_appender = std::sync::Mutex::new(file);
     tracing_subscriber::fmt()
@@ -43,8 +47,8 @@ fn windows_main() -> anyhow::Result<()> {
     )));
 
     // Connect to the proxy configured via LIGHTSPEED_PROXY env var.
-    let proxy_addr = std::env::var("LIGHTSPEED_PROXY")
-        .unwrap_or_else(|_| "127.0.0.1:4434".to_string());
+    let proxy_addr =
+        std::env::var("LIGHTSPEED_PROXY").unwrap_or_else(|_| "127.0.0.1:4434".to_string());
     let proxy: std::net::SocketAddrV4 = proxy_addr.parse().unwrap();
     engine.lock().unwrap().connect(proxy);
 
@@ -60,10 +64,10 @@ fn windows_main() -> anyhow::Result<()> {
     eframe::run_native(
         "⚡ LightSpeed",
         native_options,
-        Box::new(move |_cc| {
-            Ok(Box::new(app::LightSpeedApp::new(Arc::clone(
-                &engine_for_closure,
-            ))))
+        Box::new(move |_cc: &eframe::CreationContext<'_>| {
+            Ok(Box::new(app::LightSpeedApp::<platform::CurrentPlatform>::new(
+                Arc::clone(&engine_for_closure),
+            )))
         }),
     )
     .map_err(|e| anyhow::anyhow!("eframe error: {}", e))?;
@@ -71,10 +75,4 @@ fn windows_main() -> anyhow::Result<()> {
     engine.lock().unwrap().disconnect();
     rt.shutdown_timeout(std::time::Duration::from_secs(2));
     Ok(())
-}
-
-#[cfg(not(windows))]
-fn windows_main() -> anyhow::Result<()> {
-    eprintln!("lightspeed-gui is Windows-only. Use the `lightspeed` CLI on this platform.");
-    std::process::exit(1);
 }

--- a/client-gui/src/main.rs
+++ b/client-gui/src/main.rs
@@ -1,33 +1,31 @@
-//! LightSpeed GUI — Windows tray icon + egui status window.
+//! LightSpeed GUI — system-tray icon + egui status window.
 //!
-//! On non-Windows platforms this binary immediately prints a message and exits
-//! with code 1, so it can be compiled cross-platform but should only be
-//! installed on Windows.
+//! Cross-platform via the `platform` module (Windows tray-icon with
+//! `tray_icon`, Linux stub).
 
 mod app;
 mod platform;
 
-fn main() -> anyhow::Result<()> {
-    windows_main()
-}
+use eframe::egui;
+use std::sync::{Arc, Mutex};
 
-// #[cfg(windows)]
-fn windows_main() -> anyhow::Result<()> {
-    use eframe::egui;
-    use std::sync::{Arc, Mutex};
+fn main() -> anyhow::Result<()> {
 
     // Redirect tracing to a file since GUI apps have no console.
     // Use a simple file appender for straightforward single-file logging.
     let path = dirs::data_local_dir()
         .unwrap_or_default()
-        .join("lightspeed")
+        .join("Lightspeed")
         .join("gui-trace.log");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("Failed to create log directory");
+    }
     let file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
         .expect("Failed to open log file");
-    let file_appender = std::sync::Mutex::new(file);
+    let file_appender = Mutex::new(file);
     tracing_subscriber::fmt()
         .with_target(false)
         .compact()

--- a/client-gui/src/platform/linux.rs
+++ b/client-gui/src/platform/linux.rs
@@ -1,9 +1,16 @@
+//! # LightSpeed GUI — Linux Platform
+//!
+//! Stub tray (Linux has no system-tray standard), font setup via
+//! Noto Color Emoji, admin check via `id -u`, capture check via
+//! `tcpdump`/`dumpcap`, and Rust port detection via `pgrep` + `ss`.
+
 use std::sync::Arc;
 
 use crate::app::{TrayState, STEAM_SERVICE_PORTS};
 use crate::platform::{self, Platform, TrayHandle};
 use eframe::egui;
 
+/// No-op tray handle for Linux (no standard system-tray on modern DEs).
 pub struct LinuxTray;
 
 impl TrayHandle for LinuxTray {
@@ -14,6 +21,11 @@ impl TrayHandle for LinuxTray {
     fn set_state(&self, _state: TrayState, _rtt_ms: f64) {}
 }
 
+/// Linux [`Platform`] backend.
+///
+/// Stub tray (no system-tray standard on modern DEs), font setup via
+/// Noto Color Emoji, admin check via `id -u`, capture check via
+/// `tcpdump`/`dumpcap`.
 pub struct LinuxPlatform;
 
 impl Platform for LinuxPlatform {

--- a/client-gui/src/platform/linux.rs
+++ b/client-gui/src/platform/linux.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use crate::app::{TrayState, GAMES, STEAM_SERVICE_PORTS};
+use crate::platform::{self, Platform, TrayHandle};
+use eframe::egui;
+
+pub struct LinuxTray;
+
+impl TrayHandle for LinuxTray {
+    fn poll_events(&self, _ctx: &egui::Context) -> Vec<crate::platform::TrayAction> {
+        Vec::new()
+    }
+
+    fn set_state(&self, _state: TrayState, _rtt_ms: f64) {}
+}
+
+pub struct LinuxPlatform;
+
+impl Platform for LinuxPlatform {
+    type Tray = LinuxTray;
+
+    fn new_tray() -> Self::Tray {
+        LinuxTray
+    }
+
+    fn is_admin() -> bool {
+        use std::process::Command;
+        Command::new("id")
+            .args(["-u"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                s.parse::<u32>().ok()
+            })
+            .map(|uid| uid == 0)
+            .unwrap_or(false)
+    }
+
+    fn is_capture_available() -> bool {
+        use std::process::Command;
+        let tcpdump = Command::new("which")
+            .args(["tcpdump"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        let dumpcap = Command::new("which")
+            .args(["dumpcap"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        tcpdump || dumpcap
+    }
+
+    fn setup_fonts(ctx: &egui::Context) {
+        let mut fonts = egui::FontDefinitions::default();
+
+        let candidates = [
+            "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",
+            "/usr/share/fonts/noto/NotoColorEmoji.ttf",
+            "/usr/share/fonts/google-noto-emoji/NotoColorEmoji.ttf",
+            "/usr/share/fonts/noto-emoji/NotoColorEmoji.ttf",
+        ];
+
+        for path in &candidates {
+            if let Ok(bytes) = std::fs::read(path) {
+                fonts.font_data.insert(
+                    "noto-emoji".to_owned(),
+                    Arc::new(egui::FontData::from_owned(bytes)),
+                );
+                for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+                    fonts
+                        .families
+                        .entry(family)
+                        .or_default()
+                        .push("noto-emoji".to_owned());
+                }
+                break;
+            }
+        }
+
+        ctx.set_fonts(fonts);
+    }
+
+    fn detect_game_ports(game_idx: usize) -> (u16, u16) {
+        let (key, _, _) = GAMES[game_idx];
+        if key == "rust" {
+            if let Some(range) = detect_rust_ports_ss() {
+                tracing::info!("Linux ss-detected Rust port range: {}-{}", range.0, range.1);
+                return range;
+            }
+            tracing::debug!("ss detection failed — using wide fallback 28015-28999");
+        }
+        platform::default_port_range(game_idx)
+    }
+
+    fn relaunch_as_admin() -> ! {
+        let exe = std::env::current_exe().unwrap_or_default();
+        let exe_str = exe.display().to_string();
+        let _ = std::process::Command::new("pkexec")
+            .args([&exe_str])
+            .spawn();
+        std::process::exit(0);
+    }
+}
+
+// ── Port detection ───────────────────────────────────────────────────────────
+
+fn detect_rust_ports_ss() -> Option<(u16, u16)> {
+    use std::process::Command;
+
+    let ps = Command::new("pgrep")
+        .args(["-x", "RustClient"])
+        .output()
+        .ok()?;
+    let pid_str = String::from_utf8_lossy(&ps.stdout).trim().to_string();
+    if pid_str.is_empty() {
+        return None;
+    }
+
+    tracing::debug!("RustClient PID = {}", pid_str);
+
+    let ss = Command::new("ss").args(["-uapn"]).output().ok()?;
+    let mut ports: Vec<u16> = Vec::new();
+
+    for line in String::from_utf8_lossy(&ss.stdout).lines() {
+        if !line.contains(&pid_str) {
+            continue;
+        }
+        // ss -uapn output lines look like:
+        // UNCONN 0 0    10.0.0.1:56962       0.0.0.0:*    users:(("RustClient",pid=1234,fd=5))
+        // We look for the foreign address column (4th whitespace-delimited field)
+        // which is the game server the socket is connected to.
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        for part in &parts {
+            if let Some(port_str) = part.rsplit(':').next() {
+                if let Ok(port) = port_str.parse::<u16>() {
+                    if port >= 1024
+                        && !STEAM_SERVICE_PORTS.contains(&port)
+                        && !ports.contains(&port)
+                    {
+                        ports.push(port);
+                    }
+                }
+            }
+            // Also check local address column for listening sockets
+            if let Some(port_str) = part.split(':').last() {
+                if let Ok(port) = port_str.trim_end_matches('*').trim().parse::<u16>() {
+                    if port >= 28015 && port <= 30000 && !ports.contains(&port) {
+                        ports.push(port);
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::debug!("RustClient candidate UDP ports: {:?}", ports);
+
+    if ports.is_empty() {
+        return None;
+    }
+
+    let lo = *ports.iter().min().unwrap();
+    let hi = *ports.iter().max().unwrap();
+    Some((lo, hi.max(lo + 2)))
+}

--- a/client-gui/src/platform/linux.rs
+++ b/client-gui/src/platform/linux.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::app::{TrayState, GAMES, STEAM_SERVICE_PORTS};
+use crate::app::{TrayState, STEAM_SERVICE_PORTS};
 use crate::platform::{self, Platform, TrayHandle};
 use eframe::egui;
 
@@ -84,16 +84,8 @@ impl Platform for LinuxPlatform {
         ctx.set_fonts(fonts);
     }
 
-    fn detect_game_ports(game_idx: usize) -> (u16, u16) {
-        let (key, _, _) = GAMES[game_idx];
-        if key == "rust" {
-            if let Some(range) = detect_rust_ports_ss() {
-                tracing::info!("Linux ss-detected Rust port range: {}-{}", range.0, range.1);
-                return range;
-            }
-            tracing::debug!("ss detection failed — using wide fallback 28015-28999");
-        }
-        platform::default_port_range(game_idx)
+    fn detect_rust_ports() -> Option<(u16, u16)> {
+        detect_rust_ports_ss()
     }
 
     fn relaunch_as_admin() -> ! {
@@ -122,6 +114,10 @@ fn detect_rust_ports_ss() -> Option<(u16, u16)> {
 
     tracing::debug!("RustClient PID = {}", pid_str);
 
+    // ss -uapn output format (columns):
+    //   UNCONN  0      0    10.0.0.1:56962    0.0.0.0:*    users:(("RustClient",pid=1234,fd=5))
+    //   col:    1      2      3        4           5               6
+    // Column 4 = local address:port, column 5 = remote address:port.
     let ss = Command::new("ss").args(["-uapn"]).output().ok()?;
     let mut ports: Vec<u16> = Vec::new();
 
@@ -129,28 +125,26 @@ fn detect_rust_ports_ss() -> Option<(u16, u16)> {
         if !line.contains(&pid_str) {
             continue;
         }
-        // ss -uapn output lines look like:
-        // UNCONN 0 0    10.0.0.1:56962       0.0.0.0:*    users:(("RustClient",pid=1234,fd=5))
-        // We look for the foreign address column (4th whitespace-delimited field)
-        // which is the game server the socket is connected to.
         let parts: Vec<&str> = line.split_whitespace().collect();
-        for part in &parts {
-            if let Some(port_str) = part.rsplit(':').next() {
-                if let Ok(port) = port_str.parse::<u16>() {
-                    if port >= 1024
-                        && !STEAM_SERVICE_PORTS.contains(&port)
-                        && !ports.contains(&port)
-                    {
-                        ports.push(port);
-                    }
+        if parts.len() < 5 {
+            continue;
+        }
+
+        // Local port (col 4) — RustClient's listening socket.
+        if let Some(port_str) = parts[3].rsplit(':').next() {
+            if let Ok(port) = port_str.parse::<u16>() {
+                if port >= 1024 && !STEAM_SERVICE_PORTS.contains(&port) && !ports.contains(&port) {
+                    ports.push(port);
                 }
             }
-            // Also check local address column for listening sockets
-            if let Some(port_str) = part.split(':').last() {
-                if let Ok(port) = port_str.trim_end_matches('*').trim().parse::<u16>() {
-                    if port >= 28015 && port <= 30000 && !ports.contains(&port) {
-                        ports.push(port);
-                    }
+        }
+
+        // Remote port (col 5) — the game server it's connected to.
+        let remote_field = parts[4].trim_end_matches('*');
+        if let Some(port_str) = remote_field.rsplit(':').next() {
+            if let Ok(port) = port_str.parse::<u16>() {
+                if port >= 1024 && !ports.contains(&port) {
+                    ports.push(port);
                 }
             }
         }
@@ -158,11 +152,5 @@ fn detect_rust_ports_ss() -> Option<(u16, u16)> {
 
     tracing::debug!("RustClient candidate UDP ports: {:?}", ports);
 
-    if ports.is_empty() {
-        return None;
-    }
-
-    let lo = *ports.iter().min().unwrap();
-    let hi = *ports.iter().max().unwrap();
-    Some((lo, hi.max(lo + 2)))
+    platform::ports_to_range(&ports)
 }

--- a/client-gui/src/platform/mod.rs
+++ b/client-gui/src/platform/mod.rs
@@ -1,3 +1,11 @@
+//! # LightSpeed GUI — Platform Abstraction
+//!
+//! Traits and helpers that isolate platform-specific concerns (system tray,
+//! font paths, admin detection, game port discovery) behind a generic
+//! [`Platform`] + [`TrayHandle`] interface.  The Windows and Linux backends
+//! live in [`windows`] and [`linux`] and are selected at compile time
+//! via `#[cfg]`.
+
 use crate::app::TrayState;
 use eframe::egui;
 

--- a/client-gui/src/platform/mod.rs
+++ b/client-gui/src/platform/mod.rs
@@ -6,6 +6,7 @@ use eframe::egui;
 ///
 /// Show-window and Quit actions are handled inside the tray (they only need
 /// the `egui::Context`) and never appear here.
+#[allow(dead_code)] // Connect/Disconnect only constructed on Windows (real tray)
 #[derive(Debug, PartialEq, Eq)]
 pub enum TrayAction {
     Connect,
@@ -13,11 +14,6 @@ pub enum TrayAction {
 }
 
 pub trait TrayHandle: Send {
-    /// Poll platform tray/menu events.
-    ///
-    /// The tray handles window-show/hide and quit internally (they only need
-    /// `ctx`).  Connect/Disconnect are returned because they need the Engine,
-    /// which only the app owns.
     fn poll_events(&self, ctx: &egui::Context) -> Vec<TrayAction>;
 
     /// Update the tray icon colour and tooltip to reflect `state`.
@@ -27,10 +23,8 @@ pub trait TrayHandle: Send {
     fn set_state(&self, state: TrayState, rtt_ms: f64);
 }
 
-/// Fallback port range for a given game index.
-///
-/// Used by both Windows and Linux port-detection paths when live
-/// detection (netstat / ss) fails or is unavailable.
+/// Shared port-range look-up used by both Windows and Linux port-detection
+/// paths when live detection (netstat / ss) fails or is unavailable.
 pub fn default_port_range(game_idx: usize) -> (u16, u16) {
     let (key, _, default_port) = crate::app::GAMES[game_idx];
     match key {
@@ -45,39 +39,69 @@ pub fn default_port_range(game_idx: usize) -> (u16, u16) {
     }
 }
 
+/// Helper: convert a list of candidate ports into a (lo, hi) range.
+///
+/// The hi end is extended by at least 2 to give the WinDivert/interceptor
+/// filter a small buffer.
+pub(crate) fn ports_to_range(ports: &[u16]) -> Option<(u16, u16)> {
+    if ports.is_empty() {
+        return None;
+    }
+    let lo = *ports.iter().min().unwrap();
+    let hi = *ports.iter().max().unwrap();
+    Some((lo, hi.max(lo + 2)))
+}
+
 pub trait Platform {
     type Tray: TrayHandle;
 
     fn new_tray() -> Self::Tray;
     fn is_admin() -> bool;
+    #[allow(dead_code)]
     fn is_capture_available() -> bool;
     fn setup_fonts(ctx: &egui::Context);
-    fn detect_game_ports(game_idx: usize) -> (u16, u16);
+
+    /// Detect active game-server ports for a game.
+    ///
+    /// The default implementation tries `detect_rust_ports()` for "rust" and
+    /// falls back to `default_port_range()`.  Override `detect_rust_ports()`
+    /// (or this method entirely) to add platform-specific detection.
+    fn detect_game_ports(game_idx: usize) -> (u16, u16) {
+        let (key, _, _) = crate::app::GAMES[game_idx];
+        if key == "rust" {
+            if let Some(range) = Self::detect_rust_ports() {
+                return range;
+            }
+        }
+        default_port_range(game_idx)
+    }
+
+    /// Platform-specific Rust port detection (tasklist+netstat on Windows,
+    /// pgrep+ss on Linux).  Returns None when the process is not running.
+    fn detect_rust_ports() -> Option<(u16, u16)> {
+        None
+    }
+
     fn relaunch_as_admin() -> !;
 }
 
 // ── Platform selection ──────────────────────────────────────────────────
 // Both modules exist on disk so the IDE can check them, but only one is
 // compiled depending on the target OS.
-//
-// NB: the #[cfg] attributes are currently commented out during development
-// to let the Linux-hosted IDE validate all code paths.  Uncomment before
-// shipping.
-// #[cfg(windows)]
+
+#[cfg(windows)]
 mod windows;
-// #[cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
 mod linux;
 
-// #[cfg(windows)]
+#[cfg(windows)]
 mod platform_impl {
-    pub use super::windows::*;
     pub type CurrentPlatform = super::windows::WindowsPlatform;
 }
 
-// #[cfg(target_os = "linux")]
-// mod platform_impl {
-//     pub use super::linux::*;
-//     pub type CurrentPlatform = super::linux::LinuxPlatform;
-// }
+#[cfg(target_os = "linux")]
+mod platform_impl {
+    pub type CurrentPlatform = super::linux::LinuxPlatform;
+}
 
 pub use platform_impl::*;

--- a/client-gui/src/platform/mod.rs
+++ b/client-gui/src/platform/mod.rs
@@ -1,0 +1,83 @@
+use crate::app::TrayState;
+use eframe::egui;
+
+/// Actions returned by [`TrayHandle::poll_events`] that the app must handle
+/// because they need the Engine (owned by the app).
+///
+/// Show-window and Quit actions are handled inside the tray (they only need
+/// the `egui::Context`) and never appear here.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TrayAction {
+    Connect,
+    Disconnect,
+}
+
+pub trait TrayHandle: Send {
+    /// Poll platform tray/menu events.
+    ///
+    /// The tray handles window-show/hide and quit internally (they only need
+    /// `ctx`).  Connect/Disconnect are returned because they need the Engine,
+    /// which only the app owns.
+    fn poll_events(&self, ctx: &egui::Context) -> Vec<TrayAction>;
+
+    /// Update the tray icon colour and tooltip to reflect `state`.
+    ///
+    /// The implementation SHOULD skip redundant updates (same state as last
+    /// call) to avoid unnecessary WM_SETICON traffic on Windows.
+    fn set_state(&self, state: TrayState, rtt_ms: f64);
+}
+
+/// Fallback port range for a given game index.
+///
+/// Used by both Windows and Linux port-detection paths when live
+/// detection (netstat / ss) fails or is unavailable.
+pub fn default_port_range(game_idx: usize) -> (u16, u16) {
+    let (key, _, default_port) = crate::app::GAMES[game_idx];
+    match key {
+        "rust" => (28015, 30000),
+        "cs2" => (27015, 27100),
+        "dota2" => (27015, 27100),
+        "valorant" => (7000, 7500),
+        "apex" => (37000, 37050),
+        "lol" => (5000, 5500),
+        "pubg" => (7777, 7843),
+        _ => (default_port, default_port),
+    }
+}
+
+pub trait Platform {
+    type Tray: TrayHandle;
+
+    fn new_tray() -> Self::Tray;
+    fn is_admin() -> bool;
+    fn is_capture_available() -> bool;
+    fn setup_fonts(ctx: &egui::Context);
+    fn detect_game_ports(game_idx: usize) -> (u16, u16);
+    fn relaunch_as_admin() -> !;
+}
+
+// ── Platform selection ──────────────────────────────────────────────────
+// Both modules exist on disk so the IDE can check them, but only one is
+// compiled depending on the target OS.
+//
+// NB: the #[cfg] attributes are currently commented out during development
+// to let the Linux-hosted IDE validate all code paths.  Uncomment before
+// shipping.
+// #[cfg(windows)]
+mod windows;
+// #[cfg(target_os = "linux")]
+mod linux;
+
+// #[cfg(windows)]
+mod platform_impl {
+    pub use super::windows::*;
+    pub type CurrentPlatform = super::windows::WindowsPlatform;
+}
+
+// #[cfg(target_os = "linux")]
+// mod platform_impl {
+//     pub use super::linux::*;
+//     pub type CurrentPlatform = super::linux::LinuxPlatform;
+// }
+
+pub use platform_impl::*;

--- a/client-gui/src/platform/windows.rs
+++ b/client-gui/src/platform/windows.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 use std::sync::Arc;
 
-use crate::app::{TrayState, GAMES, STEAM_SERVICE_PORTS};
+use crate::app::{TrayState, STEAM_SERVICE_PORTS};
 use crate::platform::{self, Platform, TrayAction, TrayHandle};
 use eframe::egui;
 use tray_icon::{
@@ -17,7 +17,7 @@ const MENU_DISCONNECT: &str = "disconnect";
 const MENU_QUIT: &str = "quit";
 
 /// SAFETY: `TrayIcon` uses `Rc<RefCell<…>>` internally on Windows, which is
-/// not `Send` by default.  However `WindowsTray` is only ever created and
+/// not `Send` by default.  However, `WindowsTray` is only ever created and
 /// accessed on the main (egui) thread — the same thread that runs the Windows
 /// message loop — so moving it across threads never happens in practice.
 unsafe impl Send for WindowsTray {}
@@ -178,22 +178,8 @@ impl Platform for WindowsPlatform {
         ctx.set_fonts(fonts);
     }
 
-    fn detect_game_ports(game_idx: usize) -> (u16, u16) {
-        let (key, _, _) = GAMES[game_idx];
-        if key == "rust" {
-            if let Some(range) = detect_rust_ports_netstat() {
-                tracing::info!(
-                    "🔍 RustClient.exe netstat-detected port range: {}-{}",
-                    range.0,
-                    range.1
-                );
-                return range;
-            }
-            tracing::debug!(
-                "RustClient.exe netstat detection failed — using wide fallback 28015-28999"
-            );
-        }
-        platform::default_port_range(game_idx)
+    fn detect_rust_ports() -> Option<(u16, u16)> {
+        detect_rust_ports_netstat()
     }
 
     fn relaunch_as_admin() -> ! {
@@ -211,7 +197,6 @@ impl Platform for WindowsPlatform {
 
 // ── Icon generation ──────────────────────────────────────────────────────────
 
-/// Procedurally rasterise a ⚡ lightning-bolt silhouette into a 32×32 RGBA icon.
 fn lightning_icon(r: u8, g: u8, b: u8) -> tray_icon::Icon {
     const SIZE: usize = 32;
     let poly: [(f32, f32); 6] = [
@@ -303,8 +288,8 @@ fn detect_rust_ports_netstat() -> Option<(u16, u16)> {
             continue;
         }
 
-        let foreign_addr = parts[2];
-        if let Some(port_str) = foreign_addr.rsplit(':').next() {
+        // Local address: parts[1]
+        if let Some(port_str) = parts[1].rsplit(':').next() {
             if let Ok(port) = port_str.parse::<u16>() {
                 if port >= 1024 && !STEAM_SERVICE_PORTS.contains(&port) && !ports.contains(&port) {
                     ports.push(port);
@@ -312,12 +297,11 @@ fn detect_rust_ports_netstat() -> Option<(u16, u16)> {
             }
         }
 
-        if ports.is_empty() {
-            if let Some(port_str) = parts[1].rsplit(':').next() {
-                if let Ok(port) = port_str.parse::<u16>() {
-                    if port >= 28015 && port <= 30000 && !ports.contains(&port) {
-                        ports.push(port);
-                    }
+        // Foreign address: parts[2]
+        if let Some(port_str) = parts[2].rsplit(':').next() {
+            if let Ok(port) = port_str.parse::<u16>() {
+                if !ports.contains(&port) && port >= 28015 && port <= 30000 {
+                    ports.push(port);
                 }
             }
         }
@@ -329,11 +313,5 @@ fn detect_rust_ports_netstat() -> Option<(u16, u16)> {
         ports
     );
 
-    if ports.is_empty() {
-        return None;
-    }
-
-    let lo = *ports.iter().min().unwrap();
-    let hi = *ports.iter().max().unwrap();
-    Some((lo, hi.max(lo + 2)))
+    platform::ports_to_range(&ports)
 }

--- a/client-gui/src/platform/windows.rs
+++ b/client-gui/src/platform/windows.rs
@@ -1,3 +1,9 @@
+//! # LightSpeed GUI — Windows Platform
+//!
+//! Real tray-icon backend using `tray_icon`, Windows-specific font paths,
+//! admin check via `net session`, capture check via `sc query npcap`, and
+//! Rust port detection via `tasklist` + `netstat`.
+
 use std::cell::Cell;
 use std::sync::Arc;
 
@@ -22,6 +28,10 @@ const MENU_QUIT: &str = "quit";
 /// message loop — so moving it across threads never happens in practice.
 unsafe impl Send for WindowsTray {}
 
+/// Windows system-tray icon with a context menu (Show, Connect, Disconnect, Quit).
+///
+/// Created via [`WindowsPlatform::new_tray`].  Runs on the egui UI thread and
+/// communicates back to the app via [`TrayHandle::poll_events`].
 pub struct WindowsTray {
     icon: TrayIcon,
     id_show: MenuId,
@@ -123,6 +133,10 @@ impl TrayHandle for WindowsTray {
     }
 }
 
+/// Windows [`Platform`] backend.
+///
+/// Uses `tray_icon` for the system tray, Win32 font paths, admin check via
+/// `net session`, and Npcap detection via `sc query`.
 pub struct WindowsPlatform;
 
 impl Platform for WindowsPlatform {

--- a/client-gui/src/platform/windows.rs
+++ b/client-gui/src/platform/windows.rs
@@ -1,0 +1,339 @@
+use std::cell::Cell;
+use std::sync::Arc;
+
+use crate::app::{TrayState, GAMES, STEAM_SERVICE_PORTS};
+use crate::platform::{self, Platform, TrayAction, TrayHandle};
+use eframe::egui;
+use tray_icon::{
+    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, MenuId},
+    TrayIcon, TrayIconBuilder, TrayIconEvent,
+};
+
+// ── Tray menu item IDs ──────────────────────────────────────────────────────
+
+const MENU_SHOW: &str = "show";
+const MENU_CONNECT: &str = "connect";
+const MENU_DISCONNECT: &str = "disconnect";
+const MENU_QUIT: &str = "quit";
+
+/// SAFETY: `TrayIcon` uses `Rc<RefCell<…>>` internally on Windows, which is
+/// not `Send` by default.  However `WindowsTray` is only ever created and
+/// accessed on the main (egui) thread — the same thread that runs the Windows
+/// message loop — so moving it across threads never happens in practice.
+unsafe impl Send for WindowsTray {}
+
+pub struct WindowsTray {
+    icon: TrayIcon,
+    id_show: MenuId,
+    id_connect: MenuId,
+    id_disconnect: MenuId,
+    id_quit: MenuId,
+    last_state: Cell<TrayState>,
+}
+
+impl WindowsTray {
+    pub fn new() -> Self {
+        let item_show = MenuItem::with_id(MENU_SHOW, "Show window", true, None);
+        let item_connect = MenuItem::with_id(MENU_CONNECT, "Connect", true, None);
+        let item_disconnect = MenuItem::with_id(MENU_DISCONNECT, "Disconnect", true, None);
+        let item_quit = MenuItem::with_id(MENU_QUIT, "Quit", true, None);
+
+        let id_show = item_show.id().clone();
+        let id_connect = item_connect.id().clone();
+        let id_disconnect = item_disconnect.id().clone();
+        let id_quit = item_quit.id().clone();
+
+        let menu = Menu::new();
+        let _ = menu.append(&item_show);
+        let _ = menu.append(&PredefinedMenuItem::separator());
+        let _ = menu.append(&item_connect);
+        let _ = menu.append(&item_disconnect);
+        let _ = menu.append(&PredefinedMenuItem::separator());
+        let _ = menu.append(&item_quit);
+
+        // Start gray (disconnected) — will update on first frame via tray state machine.
+        let icon = lightning_icon(160, 160, 160);
+
+        let icon = TrayIconBuilder::new()
+            .with_menu(Box::new(menu))
+            .with_tooltip("\u{26a1} LightSpeed \u{2014} disconnected")
+            .with_icon(icon)
+            .build()
+            .expect("Failed to create tray icon");
+
+        WindowsTray {
+            icon,
+            id_show,
+            id_connect,
+            id_disconnect,
+            id_quit,
+            last_state: Cell::new(TrayState::Disconnected),
+        }
+    }
+}
+
+impl TrayHandle for WindowsTray {
+    fn poll_events(&self, ctx: &egui::Context) -> Vec<TrayAction> {
+        let mut actions = Vec::new();
+        while let Ok(event) = MenuEvent::receiver().try_recv() {
+            tracing::debug!("Tray menu event: {:?}", event.id);
+            if event.id == self.id_show {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+            } else if event.id == self.id_connect {
+                actions.push(TrayAction::Connect);
+            } else if event.id == self.id_disconnect {
+                actions.push(TrayAction::Disconnect);
+            } else if event.id == self.id_quit {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        }
+        while let Ok(event) = TrayIconEvent::receiver().try_recv() {
+            if matches!(event, TrayIconEvent::DoubleClick { .. }) {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+            }
+        }
+        actions
+    }
+
+    fn set_state(&self, state: TrayState, rtt_ms: f64) {
+        if self.last_state.get() == state {
+            return;
+        }
+        self.last_state.set(state);
+
+        let (r, g, b): (u8, u8, u8) = match state {
+            TrayState::Disconnected => (160, 160, 160),
+            TrayState::Connected => (255, 200, 60),
+            TrayState::Optimizing => (80, 210, 120),
+            TrayState::Error => (220, 80, 80),
+        };
+        let tooltip: String = match state {
+            TrayState::Disconnected => "\u{26a1} LightSpeed \u{2014} disconnected".into(),
+            TrayState::Connected => {
+                format!("\u{26a1} LightSpeed \u{2014} connected \u{00b7} RTT {:.0}ms", rtt_ms)
+            }
+            TrayState::Optimizing => "\u{26a1} LightSpeed \u{2014} optimizing".into(),
+            TrayState::Error => "\u{26a1} LightSpeed \u{2014} error".into(),
+        };
+
+        let _ = self.icon.set_icon(Some(lightning_icon(r, g, b)));
+        let _ = self.icon.set_tooltip(Some(&tooltip));
+    }
+}
+
+pub struct WindowsPlatform;
+
+impl Platform for WindowsPlatform {
+    type Tray = WindowsTray;
+
+    fn new_tray() -> Self::Tray {
+        WindowsTray::new()
+    }
+
+    fn is_admin() -> bool {
+        use std::process::Command;
+        Command::new("net")
+            .args(["session"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn is_capture_available() -> bool {
+        use std::process::Command;
+        Command::new("sc")
+            .args(["query", "npcap"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn setup_fonts(ctx: &egui::Context) {
+        let mut fonts = egui::FontDefinitions::default();
+
+        if let Ok(bytes) = std::fs::read(r"C:\Windows\Fonts\seguiemj.ttf") {
+            fonts.font_data.insert(
+                "seguiemj".to_owned(),
+                Arc::new(egui::FontData::from_owned(bytes)),
+            );
+            for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+                fonts.families.entry(family).or_default().push("seguiemj".to_owned());
+            }
+        }
+
+        if let Ok(bytes) = std::fs::read(r"C:\Windows\Fonts\seguisym.ttf") {
+            fonts.font_data.insert(
+                "seguisym".to_owned(),
+                Arc::new(egui::FontData::from_owned(bytes)),
+            );
+            fonts
+                .families
+                .entry(egui::FontFamily::Proportional)
+                .or_default()
+                .push("seguisym".to_owned());
+        }
+
+        ctx.set_fonts(fonts);
+    }
+
+    fn detect_game_ports(game_idx: usize) -> (u16, u16) {
+        let (key, _, _) = GAMES[game_idx];
+        if key == "rust" {
+            if let Some(range) = detect_rust_ports_netstat() {
+                tracing::info!(
+                    "🔍 RustClient.exe netstat-detected port range: {}-{}",
+                    range.0,
+                    range.1
+                );
+                return range;
+            }
+            tracing::debug!(
+                "RustClient.exe netstat detection failed — using wide fallback 28015-28999"
+            );
+        }
+        platform::default_port_range(game_idx)
+    }
+
+    fn relaunch_as_admin() -> ! {
+        let exe = std::env::current_exe()
+            .unwrap_or_default()
+            .display()
+            .to_string();
+        let script = format!("Start-Process '{}' -Verb RunAs", exe.replace('\'', "''"));
+        let _ = std::process::Command::new("powershell")
+            .args(["-WindowStyle", "Hidden", "-Command", &script])
+            .spawn();
+        std::process::exit(0);
+    }
+}
+
+// ── Icon generation ──────────────────────────────────────────────────────────
+
+/// Procedurally rasterise a ⚡ lightning-bolt silhouette into a 32×32 RGBA icon.
+fn lightning_icon(r: u8, g: u8, b: u8) -> tray_icon::Icon {
+    const SIZE: usize = 32;
+    let poly: [(f32, f32); 6] = [
+        (0.55, 0.02),
+        (0.18, 0.48),
+        (0.50, 0.48),
+        (0.10, 0.98),
+        (0.82, 0.52),
+        (0.50, 0.52),
+    ];
+
+    let mut rgba = vec![0u8; SIZE * SIZE * 4];
+    for y in 0..SIZE {
+        for x in 0..SIZE {
+            let px = (x as f32 + 0.5) / SIZE as f32;
+            let py = (y as f32 + 0.5) / SIZE as f32;
+            if point_in_poly(px, py, &poly) {
+                let idx = (y * SIZE + x) * 4;
+                rgba[idx] = r;
+                rgba[idx + 1] = g;
+                rgba[idx + 2] = b;
+                rgba[idx + 3] = 255;
+            }
+        }
+    }
+    tray_icon::Icon::from_rgba(rgba, SIZE as u32, SIZE as u32)
+        .expect("Failed to build tray icon from RGBA data")
+}
+
+fn point_in_poly(px: f32, py: f32, poly: &[(f32, f32)]) -> bool {
+    let n = poly.len();
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = poly[i];
+        let (xj, yj) = poly[j];
+        if ((yi > py) != (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+// ── Port detection ───────────────────────────────────────────────────────────
+
+fn detect_rust_ports_netstat() -> Option<(u16, u16)> {
+    use std::process::Command;
+
+    let tl = Command::new("tasklist")
+        .args(["/FI", "IMAGENAME eq RustClient.exe", "/FO", "CSV", "/NH"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&tl.stdout);
+    if text.trim().to_ascii_lowercase().starts_with("info:") || text.trim().is_empty() {
+        tracing::debug!("RustClient.exe not found in tasklist");
+        return None;
+    }
+    let pid: u32 = text
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split(',');
+            let _name = fields.next()?;
+            fields.next()?.trim().trim_matches('"').parse().ok()
+        })
+        .next()?;
+
+    tracing::debug!("RustClient.exe PID = {}", pid);
+
+    let ns = Command::new("netstat")
+        .args(["-ano", "-p", "UDP"])
+        .output()
+        .ok()?;
+
+    let pid_str = pid.to_string();
+    let mut ports: Vec<u16> = Vec::new();
+
+    for line in String::from_utf8_lossy(&ns.stdout).lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 4 {
+            continue;
+        }
+        if !parts[0].eq_ignore_ascii_case("UDP") {
+            continue;
+        }
+
+        let line_pid = parts.last().unwrap_or(&"");
+        if *line_pid != pid_str {
+            continue;
+        }
+
+        let foreign_addr = parts[2];
+        if let Some(port_str) = foreign_addr.rsplit(':').next() {
+            if let Ok(port) = port_str.parse::<u16>() {
+                if port >= 1024 && !STEAM_SERVICE_PORTS.contains(&port) && !ports.contains(&port) {
+                    ports.push(port);
+                }
+            }
+        }
+
+        if ports.is_empty() {
+            if let Some(port_str) = parts[1].rsplit(':').next() {
+                if let Ok(port) = port_str.parse::<u16>() {
+                    if port >= 28015 && port <= 30000 && !ports.contains(&port) {
+                        ports.push(port);
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::debug!(
+        "RustClient.exe (PID {}) candidate UDP ports: {:?}",
+        pid,
+        ports
+    );
+
+    if ports.is_empty() {
+        return None;
+    }
+
+    let lo = *ports.iter().min().unwrap();
+    let hi = *ports.iter().max().unwrap();
+    Some((lo, hi.max(lo + 2)))
+}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -47,8 +47,8 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rcgen = { version = "0.13", optional = true }
 pcap = { version = "2", optional = true }
 linfa = { version = "0.8", optional = true }
-linfa-linear = { version = "0.7", optional = true }
-ndarray = { version = "0.15", optional = true }
+linfa-linear = { version = "0.8", optional = true }
+ndarray = { version = "0.16", optional = true }
 bincode = { version = "1", optional = true }
 rand = "0.8"
 


### PR DESCRIPTION
# Cross-platform GUI refactor — platform/ trait + proxy manager + crash fixes
This PR refactors lightspeed-gui (the client-gui crate) from a Windows-only binary into a cross-platform application behind a Platform trait, while fixing two crashes and adding a proxy management UI.

## Bug Fixes

### Crash 1 — Hardcoded log path panics on non-"User" accounts
The trace log file was hardcoded to C:\Users\User\ls-gui-trace.log, which only works when the Windows username is literally User. On any real system the file-open fails and panics at startup.
Fix: Use dirs::data_local_dir() → %LOCALAPPDATA%/lightspeed/gui-trace.log on Windows (and the equivalent XDG path on Linux).

### Crash 2 — Proxy selection panics on placeholder IPs
The PROXIES constant contained placeholder addresses ("YOUR_LAX_IP:4434", "YOUR_SGP_IP:4434", etc.) that are not valid SocketAddrV4 values. Clicking any proxy button caused a panic: parse().expect("proxy addr is always valid").
Fix: Replace the const with load_proxies() that reads the LIGHTSPEED_PROXIES environment variable (comma-separated addr:port pairs) at runtime. Falls back to 127.0.0.1:4434 — no crash, just a silent connect failure if unconfigured. Invalid addresses are logged with tracing::warn! and skipped.

## Features
### 1. Cross-platform architecture (Platform trait)
Extracted all Windows-specific code behind a platform/ module with two traits:
- Platform — system checks, font loading, port detection, admin relaunch
- TrayHandle — tray icon polling, state/set state
- LightSpeedApp is now generic: LightSpeedApp<P: Platform>
- platform/windows.rs (317 LoC) — Full tray icon with tray_icon crate, Segoe UI Emoji font loading, Npcap detection via sc query, Rust process port detection via tasklist + netstat, UAC admin relaunch via PowerShell
- platform/linux.rs (156 LoC) — Stub tray (no system tray on Linux), Noto Color Emoji font loading, Rust process port detection via pgrep + ss, admin relaunch via pkexec, admin check via id -u
- platform/mod.rs — Trait definitions, default_port_range() helper, ports_to_range() helper, TrayAction enum for tray→app communication

### 2. Proxy Manager UI
Added an in-app window that lets users add, remove, and list proxy servers at runtime — no environment variable restart needed. Proxies are ephemeral (in-memory, current session only).
- Button ✎ Manage next to the proxy selector opens the manager window
- Each entry shows its label, address, and a ✕ remove button
- Label + address fields to add new proxies
- Persistence is intentionally omitted (suggested for a future PR)

### 3. egui 0.35 API migration
Updated to the current egui API:
- fn update(&mut self, ctx, _frame) → fn ui(&mut self, ui, _frame)
- Frame::none() → Frame::new().corner_radius(4.0)
- CentralPanel::show(ctx, ...) → show(ui, ...)
- Line::new(points).name(...) → Line::new("RTT (ms)", points)
### 4. Code quality
- Removed ~400 lines of dead/window-specific code from app.rs (tray builder, font loading, system checks, port detection, admin relaunch)
- Added module-level //! docs and public /// doc comments matching the project's conventions
- All Windows stubs (#[cfg(not(windows))] fn windows_main()) replaced by the platform trait

## Commits
5610358 refactor: platform specific logic and ui code separated
e1b8e5e feat: prompt window for custom proxy server added
5989110 docs: docstrings added

## Testing
- cargo check -p lightspeed-gui — passes on both Windows and Linux (Linux via CurrentPlatform = LinuxPlatform)
- To point at actual proxies: LIGHTSPEED_PROXIES="1.2.3.4:4434,5.6.7.8:4434" cargo run -p lightspeed-gui
- cargo test --workspace -- all tests pass